### PR TITLE
Fixes and addendum

### DIFF
--- a/config.yml.template
+++ b/config.yml.template
@@ -1,6 +1,3 @@
-samples:
-  - sampleID1
-  - sampleID2
 fastq_dir: /path/to/fastq/dir
 genome: /paht/to/ref/genome.fa.gz  # compressed Fasta (bgzip) with index (samtools faidx)
 variants: /path/to/variants.vcf.gz # compressed VCF (bgzip) with index (tabix)

--- a/config.yml.template
+++ b/config.yml.template
@@ -1,6 +1,9 @@
 fastq_dir: /path/to/fastq/dir
-genome: /paht/to/ref/genome.fa.gz  # compressed Fasta (bgzip) with index (samtools faidx)
+genome: /path/to/ref/genome.fa.gz  # compressed Fasta (bgzip) with index (samtools faidx)
+ngenome: path/to/nmasked/genome.fa.gz # compressed Fasta for N-masked genome / default genome. Used to generate non-phased results.
 variants: /path/to/variants.vcf.gz # compressed VCF (bgzip) with index (tabix)
 hap_1: HAPLOTYPE_ID_1              # as defined in VCF file
 hap_2: HAPLOTYPE_ID_2              # as defined in VCF file
-pairtools_parse_params: "--min-mapq 0 --add-columns XA,NM,AS,XS --drop-sam --walks-policy all"
+bwa_parameters:
+  diploid_genome: "-SPu -T0"
+  nmask_genome: "-5SP -T0"

--- a/env.yml
+++ b/env.yml
@@ -12,6 +12,8 @@ dependencies:
   - multiqc
   - pairtools==1.1
   - python
+  - snakemake >= 8
   - pip
   - pip:
       - git+https://github.com/open2c/MultiQC.git
+      - snakemake-executor-plugin-cluster-generic"

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -88,7 +88,9 @@ rule index_diploid_genome:
         genome = "02_diploid_genome/diploid_genome.fa.gz"
     output:
         index = "02_diploid_genome/diploid_genome.fa.gz.bwt"
-    threads: 1
+    threads: 2
+    resources:
+      mem_mb = 50000000
     shell:
         """
         bwa index {input.genome}

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -5,10 +5,34 @@
 import yaml
 from pathlib import Path
 
+# Set variables
 wildcard_constraints: sample=r".+\d+"
 SAMPLES, = glob_wildcards(
     Path(config['fastq_dir']) / '{sample}_R1.fastq.gz'
 )
+REFERENCES = config['bwa_parameters'].keys()
+PHASETYPES = [
+    config['hap_1'],
+    config['hap_2'],
+    'unphased',
+    'trans'
+]
+
+PHASEFILTER = [
+    '(phase1=="0") and (phase2=="0")',
+    '(phase1=="1") and (phase2=="1")',
+    '(phase1==".") or (phase2==".")',
+    '(phase1!=phase2) and (phase1!=".") and (phase2!=".") and (phase1!="!") and (phase2!="!")'
+]
+PHASEDIC = dict(map(lambda i,j : (i,j) , PHASETYPES, PHASEFILTER))
+
+# Define function that returns pair files (phased or unphased), based on the reference.
+def ret_pair(wildcards):
+    if 'diploid' in wildcards.ref:
+        # Phased setting
+        return f"04_pairing/{wildcards.sample}_{wildcards.ref}_phased.pairs.gz"
+    else:
+        return f"04_pairing/{wildcards.sample}_{wildcards.ref}.pairs.gz"
 
 # before running the process
 onstart:
@@ -50,7 +74,7 @@ rule diploid_genome:
         genome = config["genome"],
         vcf = config["variants"]
     output:
-        genome = "02_diploid_genome/diploid_genome.fa.gz"
+        genome = "02_bwa_index/diploid_genome.fa.gz"
     threads: 4
     params:
         hap1 = config["hap_1"],
@@ -77,48 +101,67 @@ rule diploid_genome:
         rm genome_{params.hap1}.fa.gz genome_{params.hap2}.fa.gz
         """
 
-rule index_diploid_genome:
+rule bwa_index_diploid_genome:
     input:
-        genome = "02_diploid_genome/diploid_genome.fa.gz"
+        genome = "02_bwa_index/diploid_genome.fa.gz"
     output:
-        index = "02_diploid_genome/diploid_genome.fa.gz.bwt"
+        index = "02_bwa_index/diploid_genome.fa.gz.bwt"
     threads: 2
     resources:
-      mem_mb = 50000
+        mem_mb = 50000
     shell:
         """
         bwa index {input.genome}
         """
 
+rule bwa_index:
+    input:
+        fna = Path(config['ngenome']).resolve()
+    output:
+        index = "02_bwa_index/nmask_genome.fa.gz.bwt"
+    threads: 2
+    resources:
+        mem_mb = 50000
+    shell:
+        """
+        ln -s {input.fna} 02_bwa_index/nmask_genome.fa.gz
+        bwa index 02_bwa_index/nmask_genome.fa.gz
+        """
+
 rule chr_sizes:
     input:
-        genome = "02_diploid_genome/diploid_genome.fa.gz"
+        bwaix = "02_bwa_index/{ref}.fa.gz.bwt"
     output:
-        chr_sizes = "02_diploid_genome/diploid_genome.chromsizes"
+        chromsize = "02_bwa_index/{ref}.chromsizes"
+    params:
+        fnagz = lambda wildcards, input: Path(input.bwaix).with_suffix('')
     threads: 1
     shell:
         """
-        samtools faidx {input.genome}
-        cut -f1,2 {input.genome}.fai > {output.chr_sizes}
+        samtools faidx {params.fnagz}
+        cut -f1,2 {params.fnagz}.fai > {output.chromsize}
         """
 
 rule bwa_mapping:
     input:
         fq1 = "01_preprocessing/{sample}_R1.fastq.gz",
         fq2 = "01_preprocessing/{sample}_R2.fastq.gz",
-        genome = "02_diploid_genome/diploid_genome.fa.gz",
-        index = "02_diploid_genome/diploid_genome.fa.gz.bwt"
+        ix = "02_bwa_index/{ref}.fa.gz.bwt"
     output:
-        bam = "03_mapping/{sample}.bam"
+        bam = "03_mapping/{sample}.{ref}.bam"
     threads: 30
     params:
-      bwathreads = 20
+      bwathreads = 20,
+      mapparams = lambda wildcards: config['bwa_parameters'][wildcards.ref],
+      fna = lambda wildcards, input: Path(input.ix).with_suffix('')
+    resources:
+      mem_mb = 3000
     shell:
         """
         bwa mem \
-            -SPu \
+            {params.mapparams} \
             -t {params.bwathreads} \
-            {input.genome} \
+            {params.fna} \
             {input.fq1} \
             {input.fq2} \
         | samtools view -@ 8 -b \
@@ -127,21 +170,21 @@ rule bwa_mapping:
 
 rule pairtools_parse:
     input:
-        bam = "03_mapping/{sample}.bam",
-        chr_sizes = "02_diploid_genome/diploid_genome.chromsizes"
+        bam = "03_mapping/{sample}.{ref}.bam",
+        chr_sizes = "02_bwa_index/{ref}.chromsizes"
     output:
-        pairs = "04_pairing/{sample}_unphased_XB.pairs.gz"
+        pairs = "04_pairing/{sample}_{ref}.pairs.gz"
     params:
-        minmapq = 0,
-        cols = 'XB,AS,XS',
+        minmapq = 40,
+        cols = lambda wildcards: '--add-columns XB,AS,XS' if 'diploid' in wildcards.ref else ''
     threads: 12
     shell:
         """
         pairtools parse \
             --min-mapq {params.minmapq} \
-            --add-columns {params.cols} \
+            {params.cols} \
             --drop-sam \
-            --walks-policy all \
+            --walks-policy 5unique \
             -c {input.chr_sizes} \
             {input.bam} \
             -o {output.pairs}
@@ -149,9 +192,9 @@ rule pairtools_parse:
 
 rule pairtools_phase:
     input:
-        pairs = "04_pairing/{sample}_unphased_XB.pairs.gz"
+        pairs = "04_pairing/{sample}_diploid_genome.pairs.gz"
     output:
-        pairs = "04_pairing/{sample}_phased_XB.pairs.gz"
+        pairs = "04_pairing/{sample}_diploid_genome_phased.pairs.gz"
     params:
         hap1 = config["hap_1"],
         hap2 = config["hap_2"]
@@ -163,35 +206,36 @@ rule pairtools_phase:
             --tag-mode XB \
             --clean-output \
             {input.pairs} -o {output.pairs}
-
         """
 
 rule pairtools_sort:
     input:
-        pairs = "04_pairing/{sample}_phased_XB.pairs.gz"
+        ret_pair
     output:
-        pairs = "04_pairing/{sample}_phased_sorted_XB.pairs.gz"
-    threads: 22
+        pairs = "04_pairing/{sample}_{ref}.pairs.sorted.gz"
+    threads: 20
     shell:
         """
         pairtools sort \
-            {input.pairs} \
-            --nproc {threads} \
-            -o {output.pairs}
+            {input} \
+            -o {output.pairs} \
+            --memory 20G
         """
 
 rule pairtools_dedup:
     input:
-        pairs = "04_pairing/{sample}_phased_sorted_XB.pairs.gz"
+        pairs = "04_pairing/{sample}_{ref}.pairs.sorted.gz"
     output:
-        pairs = "04_pairing/{sample}_dedup_XB.pairs.gz",
-        stats = "04_pairing/{sample}_dedup_XB.stats"
-    threads: 10
+        pairs = "04_pairing/{sample}_{ref}.pairs.dedup.gz",
+        stats = "04_pairing/{sample}_{ref}.pairs.dedup.stats"
+    params:
+        extra_cols = lambda wildcards: '--extra-col-pair phase1 phase2'  if 'diploid' in wildcards.ref else ''
+    threads: 12
     shell:
         """
         pairtools dedup \
             --mark-dups \
-            --extra-col-pair phase1 phase2 \
+            {params.extra_cols} \
             --output-dups - \
             --output-unmapped - \
             --output-stats {output.stats} \
@@ -199,61 +243,39 @@ rule pairtools_dedup:
             {input.pairs}
         """
 
-rule pairtools_filter:
+rule pairtools_filter_phased:
     input:
-        pairs = "04_pairing/{sample}_dedup_XB.pairs.gz"
+        pairs = "04_pairing/{sample}_diploid_genome.pairs.dedup.gz"
     output:
-        pairs0 = "05_filter/{sample}_phases_XB_" + config['hap_1'] + ".pairs.gz",
-        pairs1 = "05_filter/{sample}_phases_XB_" + config['hap_2'] + ".pairs.gz",
-        pairsU = "05_filter/{sample}_phases_XB_unphased.pairs.gz",
-        pairsT = "05_filter/{sample}_phases_XB_trans.pairs.gz"       
-    threads: 10
+        stats = "05_phase_stats/{sample}_diploid_genome_{phasetype}.pairs.stats",
+        pairs = "05_phase_stats/{sample}_diploid_genome_{phasetype}.pairs.gz"
+    params:
+        filterparam = lambda wildcards: PHASEDIC[wildcards.phasetype]
+    resources:
+        mem_mb = 1000
+    threads: 12
     shell:
         """
         pairtools select \
-            '(phase1=="0") and (phase2=="0")' \
+            '{params.filterparam}' \
             {input.pairs} \
-            -o {output.pairs0}
-
-        pairtools select \
-            '(phase1=="1") and (phase2=="1")' \
-            {input.pairs} \
-            -o {output.pairs1}
-        
-        pairtools select \
-            '(phase1==".") or (phase2==".")' \
-            {input.pairs} \
-            -o {output.pairsU}
-
-        pairtools select \
-            '(phase1!=phase2) and (phase1!=".") and (phase2!=".") and (phase1!="!") and (phase2!="!")' \
-            {input.pairs} \
-            -o {output.pairsT}
+            -o {output.pairs}
+        pairtools stats {output.pairs} -o {output.stats}
         """
 
-rule pairtools_stats:
-    input:
-        pairs0 = "05_filter/{sample}_phases_XB_" + config['hap_1'] + ".pairs.gz",
-        pairs1 = "05_filter/{sample}_phases_XB_" + config['hap_2'] + ".pairs.gz",
-        pairsU = "05_filter/{sample}_phases_XB_unphased.pairs.gz",
-        pairsT = "05_filter/{sample}_phases_XB_trans.pairs.gz"
-    output:
-        stats0 = "06_stats/{sample}_phases_XB_" + config['hap_1'] + ".stats",
-        stats1 = "06_stats/{sample}_phases_XB_" + config['hap_2'] + ".stats",
-        statsU = "06_stats/{sample}_phases_XB_unphased.stats",
-        statsT = "06_stats/{sample}_phases_XB_trans.stats"
-    threads: 10
-    shell:
-        """
-        pairtools stats {input.pairs0} -o {output.stats0}
-        pairtools stats {input.pairs1} -o {output.stats1}
-        pairtools stats {input.pairsU} -o {output.statsU}
-        pairtools stats {input.pairsT} -o {output.statsT}
-        """
 
 rule multiqc:
     input:
-        statsT = expand("06_stats/{sample}_phases_XB_trans.stats", sample=SAMPLES)
+        stats = expand(
+            "04_pairing/{sample}_{ref}.pairs.dedup.stats",
+            sample=SAMPLES,
+            ref=REFERENCES
+        ),
+        phasedstats = expand(
+            "05_phase_stats/{sample}_diploid_genome_{phasetype}.pairs.stats",
+            sample=SAMPLES,
+            phasetype = PHASEDIC.keys()
+        )
     output:
         html = "07_multiqc/multiqc_report.html"
     params:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -136,14 +136,18 @@ rule pairtools_parse:
         bam = "03_mapping/{sample}.bam",
         chr_sizes = "02_diploid_genome/diploid_genome.chromsizes"
     output:
-        pairs = "04_pairing/{sample}_unphased_XA.pairs.gz"
+        pairs = "04_pairing/{sample}_unphased_XB.pairs.gz"
     params:
-        par = config['pairtools_parse_params']
-    threads: 10
+        minmapq = 0,
+	cols = 'XB,AS,XS',
+    threads: 12
     shell:
         """
         pairtools parse \
-            {params.par} \
+            --min-mapq {params.minmapq} \
+	    --add-columns {params.cols} \
+	    --drop-sam \
+	    --walks-policy all \
             -c {input.chr_sizes} \
             {input.bam} \
             -o {output.pairs}
@@ -151,18 +155,18 @@ rule pairtools_parse:
 
 rule pairtools_phase:
     input:
-        pairs = "04_pairing/{sample}_unphased_XA.pairs.gz"
+        pairs = "04_pairing/{sample}_unphased_XB.pairs.gz"
     output:
-        pairs = "04_pairing/{sample}_phased_XA.pairs.gz"
+        pairs = "04_pairing/{sample}_phased_XB.pairs.gz"
     params:
         hap1 = config["hap_1"],
         hap2 = config["hap_2"]
-    threads: 10
+    threads: 12
     shell:
         """
         pairtools phase \
             --phase-suffixes _{params.hap1} _{params.hap2} \
-            --tag-mode XA \
+            --tag-mode XB \
             --clean-output \
             {input.pairs} -o {output.pairs}
 
@@ -170,10 +174,10 @@ rule pairtools_phase:
 
 rule pairtools_sort:
     input:
-        pairs = "04_pairing/{sample}_phased_XA.pairs.gz"
+        pairs = "04_pairing/{sample}_phased_XB.pairs.gz"
     output:
-        pairs = "04_pairing/{sample}_phased_sorted_XA.pairs.gz"
-    threads: 10
+        pairs = "04_pairing/{sample}_phased_sorted_XB.pairs.gz"
+    threads: 22
     shell:
         """
         pairtools sort \
@@ -184,10 +188,10 @@ rule pairtools_sort:
 
 rule pairtools_dedup:
     input:
-        pairs = "04_pairing/{sample}_phased_sorted_XA.pairs.gz"
+        pairs = "04_pairing/{sample}_phased_sorted_XB.pairs.gz"
     output:
-        pairs = "04_pairing/{sample}_dedup_XA.pairs.gz",
-        stats = "04_pairing/{sample}_dedup_XA.stats"
+        pairs = "04_pairing/{sample}_dedup_XB.pairs.gz",
+        stats = "04_pairing/{sample}_dedup_XB.stats"
     threads: 10
     shell:
         """
@@ -203,12 +207,12 @@ rule pairtools_dedup:
 
 rule pairtools_filter:
     input:
-        pairs = "04_pairing/{sample}_dedup_XA.pairs.gz"
+        pairs = "04_pairing/{sample}_dedup_XB.pairs.gz"
     output:
-        pairs0 = "05_filter/{sample}_phases_XA_" + config['hap_1'] + ".pairs.gz",
-        pairs1 = "05_filter/{sample}_phases_XA_" + config['hap_2'] + ".pairs.gz",
-        pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
-        pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"       
+        pairs0 = "05_filter/{sample}_phases_XB_" + config['hap_1'] + ".pairs.gz",
+        pairs1 = "05_filter/{sample}_phases_XB_" + config['hap_2'] + ".pairs.gz",
+        pairsU = "05_filter/{sample}_phases_XB_unphased.pairs.gz",
+        pairsT = "05_filter/{sample}_phases_XB_trans.pairs.gz"       
     threads: 10
     shell:
         """
@@ -235,15 +239,15 @@ rule pairtools_filter:
 
 rule pairtools_stats:
     input:
-        pairs0 = "05_filter/{sample}_phases_XA_" + config['hap_1'] + ".pairs.gz",
-        pairs1 = "05_filter/{sample}_phases_XA_" + config['hap_2'] + ".pairs.gz",
-        pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
-        pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"
+        pairs0 = "05_filter/{sample}_phases_XB_" + config['hap_1'] + ".pairs.gz",
+        pairs1 = "05_filter/{sample}_phases_XB_" + config['hap_2'] + ".pairs.gz",
+        pairsU = "05_filter/{sample}_phases_XB_unphased.pairs.gz",
+        pairsT = "05_filter/{sample}_phases_XB_trans.pairs.gz"
     output:
-        stats0 = "06_stats/{sample}_phases_XA_" + config['hap_1'] + ".stats",
-        stats1 = "06_stats/{sample}_phases_XA_" + config['hap_2'] + ".stats",
-        statsU = "06_stats/{sample}_phases_XA_unphased.stats",
-        statsT = "06_stats/{sample}_phases_XA_trans.stats"
+        stats0 = "06_stats/{sample}_phases_XB_" + config['hap_1'] + ".stats",
+        stats1 = "06_stats/{sample}_phases_XB_" + config['hap_2'] + ".stats",
+        statsU = "06_stats/{sample}_phases_XB_unphased.stats",
+        statsT = "06_stats/{sample}_phases_XB_trans.stats"
     threads: 10
     shell:
         """
@@ -255,7 +259,7 @@ rule pairtools_stats:
 
 rule multiqc:
     input:
-        statsT = expand("06_stats/{sample}_phases_XA_trans.stats", sample=config['samples'])
+        statsT = expand("06_stats/{sample}_phases_XB_trans.stats", sample=config['samples'])
     output:
         html = "07_multiqc/multiqc_report.html"
     params:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -266,7 +266,7 @@ rule multiqc:
         multiqc \
             --module pairtools \
             -o {params.odir} \
-            06_stats/
+            .
         """
 
 onsuccess:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -90,7 +90,7 @@ rule index_diploid_genome:
         index = "02_diploid_genome/diploid_genome.fa.gz.bwt"
     threads: 2
     resources:
-      mem_mb = 50000000
+      mem_mb = 50000
     shell:
         """
         bwa index {input.genome}

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -57,7 +57,7 @@ rule diploid_genome:
         vcf = str(config["variants"])
     output:
         genome = "02_diploid_genome/diploid_genome.fa.gz"
-    threads: 1
+    threads: 4
     params:
         hap1 = config["hap_1"],
         hap2 = config["hap_2"]
@@ -139,7 +139,7 @@ rule pairtools_parse:
         pairs = "04_pairing/{sample}_unphased_XA.pairs.gz"
     params:
         par = config['pairtools_parse_params']
-    threads: 1
+    threads: 10
     shell:
         """
         pairtools parse \
@@ -157,7 +157,7 @@ rule pairtools_phase:
     params:
         hap1 = config["hap_1"],
         hap2 = config["hap_2"]
-    threads: 1
+    threads: 10
     shell:
         """
         pairtools phase \
@@ -188,7 +188,7 @@ rule pairtools_dedup:
     output:
         pairs = "04_pairing/{sample}_dedup_XA.pairs.gz",
         stats = "04_pairing/{sample}_dedup_XA.stats"
-    threads: 1
+    threads: 10
     shell:
         """
         pairtools dedup \
@@ -209,7 +209,7 @@ rule pairtools_filter:
         pairs1 = "05_filter/{sample}_phases_XA_" + config['hap_2'] + ".pairs.gz",
         pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
         pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"       
-    threads: 1
+    threads: 10
     shell:
         """
         pairtools select \
@@ -244,7 +244,7 @@ rule pairtools_stats:
         stats1 = "05_stats/{sample}_phases_XA_" + config['hap_2'] + ".stats",
         statsU = "06_stats/{sample}_phases_XA_unphased.stats",
         statsT = "06_stats/{sample}_phases_XA_trans.stats"
-    threads: 1
+    threads: 10
     shell:
         """
         pairtools stats {input.pairs0} -o {output.stats0}

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,7 +27,7 @@ onstart:
 # main workflow
 rule all:
     input:
-        expand("07_multiqc/{sample}/multiqc_report.html", sample=config["samples"]) 
+        "07_multiqc/multiqc_report.html"
 
 rule fastp:
     input:
@@ -255,16 +255,17 @@ rule pairtools_stats:
 
 rule multiqc:
     input:
-        statsT = "06_stats/{sample}_phases_XA_trans.stats"
+        statsT = expand("06_stats/{sample}_phases_XA_trans.stats", sample=config['samples'])
     output:
-        dir = directory("07_multiqc/{sample}"),
-        html = "07_multiqc/{sample}/multiqc_report.html"
+        html = "07_multiqc/multiqc_report.html"
+    params:
+        odir = "07_multiqc"
     threads: 1
     shell:
         """
         multiqc \
             --module pairtools \
-            -o {output.dir} \
+            -o {params.odir} \
             06_stats/
         """
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -3,18 +3,13 @@
 # (C) 2024
 
 import yaml
+from pathlib import Path
 
 wildcard_constraints: sample=r".+\d+"
+SAMPLES, = glob_wildcards(
+    Path(config['fastq_dir']) / '{sample}_R1.fastq.gz'
+)
 
-# some subroutines needed
-def dump_config_to_yaml(config):
-    output_file = "run_config.yaml"
-    with open(output_file, 'w') as configfile:
-        yaml.dump(config, configfile)
-
-# setting configurations
-configfile: "config.yaml"
-fastq_dir = str(config['fastq_dir'])
 # before running the process
 onstart:
     print("\n==== Variant calling pipeline starts ====")
@@ -22,7 +17,6 @@ onstart:
     print(config)
     print("=" * 80)
     print()
-    dump_config_to_yaml(config)
 
 # main workflow
 rule all:
@@ -31,8 +25,8 @@ rule all:
 
 rule fastp:
     input:
-        fq1 = str(fastq_dir) + "/{sample}_R1.fastq.gz",
-        fq2 = str(fastq_dir) + "/{sample}_R2.fastq.gz"
+        fq1 = config['fastq_dir'] + "/{sample}_R1.fastq.gz",
+        fq2 = config['fastq_dir'] + "/{sample}_R2.fastq.gz"
     output:
         trim_fq1 = "01_preprocessing/{sample}_R1.fastq.gz",
         trim_fq2 = "01_preprocessing/{sample}_R2.fastq.gz",
@@ -53,8 +47,8 @@ rule fastp:
 
 rule diploid_genome:
     input:
-        genome = str(config["genome"]),
-        vcf = str(config["variants"])
+        genome = config["genome"],
+        vcf = config["variants"]
     output:
         genome = "02_diploid_genome/diploid_genome.fa.gz"
     threads: 4
@@ -259,7 +253,7 @@ rule pairtools_stats:
 
 rule multiqc:
     input:
-        statsT = expand("06_stats/{sample}_phases_XB_trans.stats", sample=config['samples'])
+        statsT = expand("06_stats/{sample}_phases_XB_trans.stats", sample=SAMPLES)
     output:
         html = "07_multiqc/multiqc_report.html"
     params:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -56,7 +56,7 @@ rule diploid_genome:
         genome = str(config["genome"]),
         vcf = str(config["variants"])
     output:
-        genome = "02_diplod_genome/diplod_genome.fa.gz"
+        genome = "02_diploid_genome/diploid_genome.fa.gz"
     threads: 1
     params:
         hap1 = config["hap_1"],
@@ -85,9 +85,9 @@ rule diploid_genome:
 
 rule index_diploid_genome:
     input:
-        genome = "02_diplod_genome/diplod_genome.fa.gz"
+        genome = "02_diploid_genome/diploid_genome.fa.gz"
     output:
-        index = "02_diplod_genome/diplod_genome.fa.gz.bwt"
+        index = "02_diploid_genome/diploid_genome.fa.gz.bwt"
     threads: 1
     shell:
         """
@@ -96,9 +96,9 @@ rule index_diploid_genome:
 
 rule chr_sizes:
     input:
-        genome = "02_diplod_genome/diplod_genome.fa.gz"
+        genome = "02_diploid_genome/diploid_genome.fa.gz"
     output:
-        chr_sizes = "02_diplod_genome/diplod_genome.chromsizes"
+        chr_sizes = "02_diploid_genome/diploid_genome.chromsizes"
     threads: 1
     shell:
         """
@@ -110,27 +110,29 @@ rule bwa_mapping:
     input:
         fq1 = "01_preprocessing/{sample}_R1.fastq.gz",
         fq2 = "01_preprocessing/{sample}_R2.fastq.gz",
-        genome = "02_diplod_genome/diplod_genome.fa.gz",
-        index = "02_diplod_genome/diplod_genome.fa.gz.bwt"
+        genome = "02_diploid_genome/diploid_genome.fa.gz",
+        index = "02_diploid_genome/diploid_genome.fa.gz.bwt"
     output:
         bam = "03_mapping/{sample}.bam"
-    threads: 10
+    threads: 30
+    params:
+      bwathreads = 20
     shell:
         """
         bwa mem \
-            -SP \
-            -t {threads} \
+            -SPu \
+            -t {params.bwathreads} \
             {input.genome} \
             {input.fq1} \
             {input.fq2} \
-        | samtools view -@ 2 -b \
+        | samtools view -@ 8 -b \
         > {output.bam}
         """
 
 rule pairtools_parse:
     input:
         bam = "03_mapping/{sample}.bam",
-        chr_sizes = "02_diplod_genome/diplod_genome.chromsizes"
+        chr_sizes = "02_diploid_genome/diploid_genome.chromsizes"
     output:
         pairs = "04_pairing/{sample}_unphased_XA.pairs.gz"
     params:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -68,19 +68,19 @@ rule diploid_genome:
             --haplotype 1 {input.vcf} \
             --sample {params.hap1} \
             | sed -E 's/(>[^[:space:]]+).*/\\1_{params.hap1}/g' \
-            | bgzip -c > genome_hap1.fa.gz
+            | bgzip -c > genome_{params.hap1}.fa.gz
 
         bcftools consensus \
             --fasta-ref {input.genome} \
             --haplotype 1 {input.vcf} \
             --sample {params.hap2} \
             | sed -E 's/(>[^[:space:]]+).*/\\1_{params.hap2}/g' \
-            | bgzip -c > genome_hap2.fa.gz
+            | bgzip -c > genome_{params.hap2}.fa.gz
 
-        cat genome_hap1.fa.gz genome_hap2.fa.gz \
+        cat genome_{params.hap1}.fa.gz genome_{params.hap2}.fa.gz \
             > {output.genome}
 
-        rm genome_hap1.fa.gz genome_hap2.fa.gz
+        rm genome_{params.hap1}.fa.gz genome_{params.hap2}.fa.gz
         """
 
 rule index_diploid_genome:
@@ -154,11 +154,14 @@ rule pairtools_phase:
         pairs = "04_pairing/{sample}_unphased_XA.pairs.gz"
     output:
         pairs = "04_pairing/{sample}_phased_XA.pairs.gz"
+    params:
+        hap1 = config["hap_1"],
+        hap2 = config["hap_2"]
     threads: 1
     shell:
         """
         pairtools phase \
-            --phase-suffixes _hap1 _hap2 \
+            --phase-suffixes _{params.hap1} _{params.hap2} \
             --tag-mode XA \
             --clean-output \
             {input.pairs} -o {output.pairs}
@@ -202,8 +205,8 @@ rule pairtools_filter:
     input:
         pairs = "04_pairing/{sample}_dedup_XA.pairs.gz"
     output:
-        pairs0 = "05_filter/{sample}_phases_XA_phase0.pairs.gz",
-        pairs1 = "05_filter/{sample}_phases_XA_phase1.pairs.gz",
+        pairs0 = "05_filter/{sample}_phases_XA_" + config['hap_1'] + ".pairs.gz",
+        pairs1 = "05_filter/{sample}_phases_XA_" + config['hap_2'] + ".pairs.gz",
         pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
         pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"       
     threads: 1
@@ -232,13 +235,13 @@ rule pairtools_filter:
 
 rule pairtools_stats:
     input:
-        pairs0 = "05_filter/{sample}_phases_XA_phase0.pairs.gz",
-        pairs1 = "05_filter/{sample}_phases_XA_phase1.pairs.gz",
+        pairs0 = "05_filter/{sample}_phases_XA_" + config['hap_1'] + ".pairs.gz",
+        pairs1 = "05_filter/{sample}_phases_XA_" + config['hap_2'] + ".pairs.gz",
         pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
         pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"
     output:
-        stats0 = "06_stats/{sample}_phases_XA_phase0.stats",
-        stats1 = "06_stats/{sample}_phases_XA_phase1.stats",
+        stats0 = "05_stats/{sample}_phases_XA_" + config['hap_1'] + ".stats",
+        stats1 = "05_stats/{sample}_phases_XA_" + config['hap_2'] + ".stats",
         statsU = "06_stats/{sample}_phases_XA_unphased.stats",
         statsT = "06_stats/{sample}_phases_XA_trans.stats"
     threads: 1
@@ -252,9 +255,6 @@ rule pairtools_stats:
 
 rule multiqc:
     input:
-        stats0 = "06_stats/{sample}_phases_XA_phase0.stats",
-        stats1 = "06_stats/{sample}_phases_XA_phase1.stats",
-        statsU = "06_stats/{sample}_phases_XA_unphased.stats",
         statsT = "06_stats/{sample}_phases_XA_trans.stats"
     output:
         dir = directory("07_multiqc/{sample}"),

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -240,8 +240,8 @@ rule pairtools_stats:
         pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
         pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"
     output:
-        stats0 = "05_stats/{sample}_phases_XA_" + config['hap_1'] + ".stats",
-        stats1 = "05_stats/{sample}_phases_XA_" + config['hap_2'] + ".stats",
+        stats0 = "06_stats/{sample}_phases_XA_" + config['hap_1'] + ".stats",
+        stats1 = "06_stats/{sample}_phases_XA_" + config['hap_2'] + ".stats",
         statsU = "06_stats/{sample}_phases_XA_unphased.stats",
         statsT = "06_stats/{sample}_phases_XA_trans.stats"
     threads: 10

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -139,15 +139,15 @@ rule pairtools_parse:
         pairs = "04_pairing/{sample}_unphased_XB.pairs.gz"
     params:
         minmapq = 0,
-	cols = 'XB,AS,XS',
+        cols = 'XB,AS,XS',
     threads: 12
     shell:
         """
         pairtools parse \
             --min-mapq {params.minmapq} \
-	    --add-columns {params.cols} \
-	    --drop-sam \
-	    --walks-policy all \
+            --add-columns {params.cols} \
+            --drop-sam \
+            --walks-policy all \
             -c {input.chr_sizes} \
             {input.bam} \
             -o {output.pairs}

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -15,7 +15,6 @@ def dump_config_to_yaml(config):
 # setting configurations
 configfile: "config.yaml"
 fastq_dir = str(config['fastq_dir'])
-
 # before running the process
 onstart:
     print("\n==== Variant calling pipeline starts ====")
@@ -32,18 +31,14 @@ rule all:
 
 rule fastp:
     input:
-        fq1 = str(fastq_dir) + "/{sample}_1.fastq.gz",
-        fq2 = str(fastq_dir) + "/{sample}_2.fastq.gz"
+        fq1 = str(fastq_dir) + "/{sample}_R1.fastq.gz",
+        fq2 = str(fastq_dir) + "/{sample}_R2.fastq.gz"
     output:
-        trim_fq1 = "01_preprocessing/{sample}_1.fastq.gz",
-        trim_fq2 = "01_preprocessing/{sample}_2.fastq.gz",
+        trim_fq1 = "01_preprocessing/{sample}_R1.fastq.gz",
+        trim_fq2 = "01_preprocessing/{sample}_R2.fastq.gz",
         html_rep = "01_preprocessing/{sample}_report.html",
         json_rep = "01_preprocessing/{sample}_report.json"
     threads: 10
-    log:
-        "logs/fastp/{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         fastp \
@@ -56,7 +51,7 @@ rule fastp:
             -j {output.json_rep}
         """
 
-rule diplod_genome:
+rule diploid_genome:
     input:
         genome = str(config["genome"]),
         vcf = str(config["variants"])
@@ -66,24 +61,20 @@ rule diplod_genome:
     params:
         hap1 = config["hap_1"],
         hap2 = config["hap_2"]
-    log:
-        "logs/bcftools/diplod_genome.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         bcftools consensus \
             --fasta-ref {input.genome} \
             --haplotype 1 {input.vcf} \
             --sample {params.hap1} \
-            | sed -E 's/(>[^[:space:]]+).*/\\1_hap1/g' \
+            | sed -E 's/(>[^[:space:]]+).*/\\1_{params.hap1}/g' \
             | bgzip -c > genome_hap1.fa.gz
 
         bcftools consensus \
             --fasta-ref {input.genome} \
             --haplotype 1 {input.vcf} \
             --sample {params.hap2} \
-            | sed -E 's/(>[^[:space:]]+).*/\\1_hap2/g' \
+            | sed -E 's/(>[^[:space:]]+).*/\\1_{params.hap2}/g' \
             | bgzip -c > genome_hap2.fa.gz
 
         cat genome_hap1.fa.gz genome_hap2.fa.gz \
@@ -98,10 +89,6 @@ rule index_diploid_genome:
     output:
         index = "02_diplod_genome/diplod_genome.fa.gz.bwt"
     threads: 1
-    log:
-        "logs/bwa/index.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         bwa index {input.genome}
@@ -113,10 +100,6 @@ rule chr_sizes:
     output:
         chr_sizes = "02_diplod_genome/diplod_genome.chromsizes"
     threads: 1
-    log:
-        "logs/faidx/chr_sizes.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         samtools faidx {input.genome}
@@ -125,17 +108,13 @@ rule chr_sizes:
 
 rule bwa_mapping:
     input:
-        fq1 = "01_preprocessing/{sample}_1.fastq.gz",
-        fq2 = "01_preprocessing/{sample}_2.fastq.gz",
+        fq1 = "01_preprocessing/{sample}_R1.fastq.gz",
+        fq2 = "01_preprocessing/{sample}_R2.fastq.gz",
         genome = "02_diplod_genome/diplod_genome.fa.gz",
         index = "02_diplod_genome/diplod_genome.fa.gz.bwt"
     output:
         bam = "03_mapping/{sample}.bam"
     threads: 10
-    log:
-        "logs/bwa/align_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         bwa mem \
@@ -157,10 +136,6 @@ rule pairtools_parse:
     params:
         par = config['pairtools_parse_params']
     threads: 1
-    log:
-        "logs/pairtools/parse_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         pairtools parse \
@@ -176,10 +151,6 @@ rule pairtools_phase:
     output:
         pairs = "04_pairing/{sample}_phased_XA.pairs.gz"
     threads: 1
-    log:
-        "logs/pairtools/phase_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         pairtools phase \
@@ -196,10 +167,6 @@ rule pairtools_sort:
     output:
         pairs = "04_pairing/{sample}_phased_sorted_XA.pairs.gz"
     threads: 10
-    log:
-        "logs/pairtools/sort_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         pairtools sort \
@@ -215,10 +182,6 @@ rule pairtools_dedup:
         pairs = "04_pairing/{sample}_dedup_XA.pairs.gz",
         stats = "04_pairing/{sample}_dedup_XA.stats"
     threads: 1
-    log:
-        "logs/pairtools/dedup_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         pairtools dedup \
@@ -240,10 +203,6 @@ rule pairtools_filter:
         pairsU = "05_filter/{sample}_phases_XA_unphased.pairs.gz",
         pairsT = "05_filter/{sample}_phases_XA_trans.pairs.gz"       
     threads: 1
-    log:
-        "logs/pairtools/stats_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         pairtools select \
@@ -279,10 +238,6 @@ rule pairtools_stats:
         statsU = "06_stats/{sample}_phases_XA_unphased.stats",
         statsT = "06_stats/{sample}_phases_XA_trans.stats"
     threads: 1
-    log:
-        "logs/pairtools/stats_{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         pairtools stats {input.pairs0} -o {output.stats0}
@@ -301,10 +256,6 @@ rule multiqc:
         dir = directory("07_multiqc/{sample}"),
         html = "07_multiqc/{sample}/multiqc_report.html"
     threads: 1
-    log:
-        "logs/multiqc/{sample}.log"
-    conda:
-        "pairtools_phased"
     shell:
         """
         multiqc \


### PR DESCRIPTION
A couple of suggestions, bug fixes and addenda:

- drop config dump, as the config is read from file anyhow
- snakemake and executor are part of the environment now
- all log / conda directives are dropped, as these were non-functional as far as I could tell
- Switched over the phasing to XB tags over XA
- haplotypes are included in the filenames now, rather then hap_1 & hap_2
- 1 multiqc run over all stat files, instead of 1 per sample
- pairtools resources were not correctly specified, number of threads and memory are updated.
- parameters for pairtools parse are set in the rule itself
- unphased run included now too (start from nmask genome). Closes #2 
- samples inferred rather then specified in config.